### PR TITLE
Add support for alternate URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules
 /static/feeds/*
 !/static/feeds/.gitkeep
+/static/alternate/*
+!/static/alternate/.gitkeep

--- a/index.ts
+++ b/index.ts
@@ -96,8 +96,14 @@ export const emailServer = new SMTPServer({
         while (
           document.querySelector("feed > entry") !== null &&
           xml.serialize().length > 500_000
-        )
-          document.querySelector("feed > entry:last-of-type")!.remove();
+        ) {
+          const lastEntry = document.querySelector("feed > entry:last-of-type");
+          const identifier = removeUrn(
+            lastEntry!.querySelector("id")!.textContent as string
+          );
+          await fs.unlink(alternatePath(identifier));
+          lastEntry!.remove();
+        }
         await writeFileAtomic(
           path,
           `<?xml version="1.0" encoding="utf-8"?>${xml.serialize()}`
@@ -233,6 +239,10 @@ function alternateURL(identifier: string): string {
 
 function urn(identifier: string): string {
   return `urn:kill-the-newsletter:${identifier}`;
+}
+
+function removeUrn(identifier: string): string {
+  return identifier.replace(urn(""), "");
 }
 
 function X(string: string): string {


### PR DESCRIPTION
When using Kill the Newsletter with IFTTT and Instapaper, the alternate link is always used, which leads to the wrong content being saved. This adds support for saving and viewing the original email content.